### PR TITLE
Added Homer Dashboard

### DIFF
--- a/services-available/homer.yml
+++ b/services-available/homer.yml
@@ -1,0 +1,29 @@
+version: '3'
+
+networks:
+  default:
+    name: traefik
+    
+# https://hub.docker.com/r/b4bz/homer
+
+services:
+  homer:
+    image: b4bz/homer:latest
+    container_name: homer
+    restart: unless-stopped
+    volumes:
+      - ./etc/homer/assets/:/www/assets
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
+    environment:
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
+      - TZ=${TZ}
+    labels:
+      - joyride.host.name=homer.${HOST_DOMAIN}
+      - traefik.enable=true
+      - traefik.http.routers.homer.entrypoints=websecure
+      - traefik.http.routers.homer.rule=Host(`homer.${HOST_DOMAIN}`)
+      - traefik.http.services.homer.loadbalancer.server.port=8080
+      - com.centurylinklabs.watchtower.enable=true
+      - autoheal=true


### PR DESCRIPTION
Created path under etc for homer/assets. When container first runs it will populate the assets directory with example files as well as the config.yml that it will load upon startup.

Should we perhaps keep this assets directory under media, in order to avoid having a directory exist under etc?